### PR TITLE
Replace compile with implementation

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -63,6 +63,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }
   


### PR DESCRIPTION
Error Configuration 'compile' is obsolete and has been replaced with 'implementation'. It will be removed at the end of 2018.
https://developer.android.com/studio/build/dependencies?utm_source=android-studio#dependency_configurations