### PR TITLE
Use OpenSSL-Universal from CocoaPods on iOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+/ios/Libraries/libcrypto.a
+/ios/Libraries/libssl.a
+/ios/Libraries/libz.a
+
 # OSX
 #
 .DS_Store
@@ -7,7 +11,6 @@
 node_modules/
 npm-debug.log
 yarn-error.log
-  
 
 # Xcode
 #

--- a/package.json
+++ b/package.json
@@ -22,7 +22,12 @@
   "files": [
     "android/*",
     "index.js",
-    "ios/*",
+    "ios/Headers",
+    "ios/Libraries/libnativecrypto.a",
+    "ios/Libraries/libsecp256k1.a",
+    "ios/RNFastCrypto.h",
+    "ios/RNFastCrypto.m",
+    "ios/RNFastCrypto.xcodeproj",
     "package.json",
     "react-native-fast-crypto.podspec",
     "README.md"

--- a/react-native-fast-crypto.podspec
+++ b/react-native-fast-crypto.podspec
@@ -18,11 +18,9 @@ Pod::Spec.new do |s|
   }
   s.source_files = "ios/**/*.{h,m}"
   s.vendored_libraries =
-    "ios/Libraries/libcrypto.a",
     "ios/Libraries/libnativecrypto.a",
-    "ios/Libraries/libsecp256k1.a",
-    "ios/Libraries/libssl.a",
-    "ios/Libraries/libz.a"
+    "ios/Libraries/libsecp256k1.a"
 
   s.dependency "React"
+  s.dependency "OpenSSL-Universal"
 end


### PR DESCRIPTION
By making the dependency on OpenSSL explicit, it works on both RN 59 and 63.