### PR TITLE
Fix insufficient malloc size for uncompressed secp256k1 public keys

### DIFF
--- a/android/src/main/cpp/crypto_bridge.cpp
+++ b/android/src/main/cpp/crypto_bridge.cpp
@@ -292,7 +292,9 @@ Java_co_airbitz_fastcrypto_RNFastCryptoModule_secp256k1EcPubkeyCreateJNI(JNIEnv 
     }
     int privateKeyLen = strlen(szPrivateKeyHex);
 
-    char szPublicKeyHex[privateKeyLen * 2];
+    // Buffer size: privateKeyLen * 2 + 3 bytes
+    // For 64-char private key: uncompressed public key = 130 hex chars (string) + 1 null terminator = 131 bytes
+    char szPublicKeyHex[privateKeyLen * 2 + 3];
 
     fast_crypto_secp256k1_ec_pubkey_create(szPrivateKeyHex, szPublicKeyHex, jiCompressed);
     jstring out = env->NewStringUTF(szPublicKeyHex);

--- a/ios/RNFastCrypto.m
+++ b/ios/RNFastCrypto.m
@@ -79,7 +79,9 @@ RCT_REMAP_METHOD(secp256k1EcPubkeyCreate,
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
-  char *szPublicKeyHex = malloc(sizeof(char) * [privateKeyHex length] * 2);
+  // Buffer size: privateKeyLen * 2 + 3 bytes
+  // For 64-char private key: uncompressed public key = 130 hex chars (string) + 1 null terminator = 131 bytes
+  char *szPublicKeyHex = malloc(sizeof(char) * ([privateKeyHex length] * 2 + 3)); 
   fast_crypto_secp256k1_ec_pubkey_create([privateKeyHex UTF8String], szPublicKeyHex, compressed);
   NSString *publicKeyHex = [NSString stringWithUTF8String:szPublicKeyHex];
   free(szPublicKeyHex);


### PR DESCRIPTION
### CHANGELOG

Does this branch warrant an entry to the CHANGELOG?

- [x] Yes
- [ ] No

### Dependencies

<!-- Replace line with PRs which this PR depends if any --> none

### Description

<!-- Describe your changes textually and/or pictorially if necessary -->

This PR fixes a bug in malloc for secp256k1EcPubkeyCreate.

The original code allocated memory for the hex-encoded public key as follows:
`char *szPublicKeyHex = malloc(sizeof(char) * [privateKeyHex length] * 2);`

However, the uncompressed public key is 65 binary bytes, or 130 hex characters. 130 hex characters in a string take 130 bytes of storage, even though they only represent 65 bytes of actual data. The buffer stores the hex string representation, not the binary data. The bytesToHex function converts 65 bytes of binary public key data into 130 hex characters (string) + 1 null terminator = 131 bytes total.
So, the uncompressed public key is 65 binary bytes → 130 ASCII hex characters → 130 bytes of storage, and you still need one extra byte for the terminating '\0', giving 131.

The current code will cause a heap overflow/corruption on iOS and stack buffer overflow on Android if secp256k1.publicKeyCreate is called with the compressed parameter set to 0/false.
